### PR TITLE
fix lambda syntax for ruby 1.9.3

### DIFF
--- a/lib/applicaster/accounts.rb
+++ b/lib/applicaster/accounts.rb
@@ -30,7 +30,7 @@ module Applicaster
             backoff_factor: 2,
             exceptions: [Faraday::ClientError, Faraday::TimeoutError],
             methods: [],
-            retry_if: -> (env, exception) {
+            retry_if: ->(env, exception) {
               env[:method] == :get &&
                 (exception.is_a?(Faraday::TimeoutError) ||
                  RETRYABLE_STATUS_CODES.include?(env[:status]))


### PR DESCRIPTION
http://ruby-journal.com/becareful-with-space-in-lambda-hash-rocket-syntax-between-ruby-1-dot-9-and-2-dot-0/