### PR TITLE
Deletes the current access token from accounts before resetting session

### DIFF
--- a/lib/applicaster/accounts.rb
+++ b/lib/applicaster/accounts.rb
@@ -97,6 +97,10 @@ module Applicaster
       access_token(omniauth_credentials).get("/api/v1/users/current.json").parsed
     end
 
+    def delete_session_for_token(token)
+      connection(token: token).delete("/api/v1/sessions/0.json")
+    end
+
     def accounts
       self.class.accounts_from_token(client_credentials_token.token)
     end

--- a/lib/applicaster/sessions_controller_mixin.rb
+++ b/lib/applicaster/sessions_controller_mixin.rb
@@ -11,6 +11,7 @@ module Applicaster
     end
 
     def destroy
+      Applicaster::Accounts.new.delete_session_for_token(current_access_token)
       reset_session
 
       redirect_to "/"

--- a/lib/omniauth-applicaster/version.rb
+++ b/lib/omniauth-applicaster/version.rb
@@ -1,5 +1,5 @@
 module OmniAuth
   module Applicaster
-    VERSION = "1.7.1"
+    VERSION = "1.7.2"
   end
 end


### PR DESCRIPTION
In this PR

When logging out from one of the Applicaster services the user stays logged in the system if he marked the `remember me option`. Here we send the current access token in order for it to be deleted so that the user is forgotten upon logout