### PR TITLE
Relax requirement on faraday

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'pry'
+gem 'excon', '< 0.63'

--- a/lib/applicaster/accounts.rb
+++ b/lib/applicaster/accounts.rb
@@ -20,7 +20,7 @@ module Applicaster
 
         Faraday.new(conn_opts) do |conn|
           if options[:token]
-            conn.request :oauth2, options[:token]
+            conn.request :oauth2, options[:token], token_type: 'param'
           end
 
           conn.request :json
@@ -89,6 +89,7 @@ module Applicaster
           config.client_secret,
           site: config.base_url,
           authorize_url: "/oauth/authorize",
+          auth_scheme: :basic_auth,
         )
       end
     end

--- a/omniauth-applicaster.gemspec
+++ b/omniauth-applicaster.gemspec
@@ -24,7 +24,8 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock"
 
   spec.add_dependency "omniauth-oauth2"
-  spec.add_dependency "faraday", "~> 0.9"
+  spec.add_dependency "faraday", "~> 0.11"
+  spec.add_dependency "oauth2", "> 1.3.1"
   spec.add_dependency "faraday_middleware"
   spec.add_dependency "excon"
   spec.add_dependency "virtus"

--- a/omniauth-applicaster.gemspec
+++ b/omniauth-applicaster.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "webmock"
 
   spec.add_dependency "omniauth-oauth2"
-  spec.add_dependency "faraday", "~> 0.9.1"
+  spec.add_dependency "faraday", "~> 0.9"
   spec.add_dependency "faraday_middleware"
   spec.add_dependency "excon"
   spec.add_dependency "virtus"

--- a/spec/support/webmock_stubs_helper.rb
+++ b/spec/support/webmock_stubs_helper.rb
@@ -10,8 +10,9 @@ module WebmockStubsHelper
   end
 
   def stub_client_credentials_request
-    stub_request(:post, "https://client-id:client-secret@#{accounts_host}/oauth/token")
+    stub_request(:post, "https://#{accounts_host}/oauth/token")
       .with(:body => {"grant_type"=>"client_credentials"})
+      .with(basic_auth: ["client-id", "client-secret"])
       .to_return(successful_json_response(access_token: "client-credentials-token"))
   end
 


### PR DESCRIPTION
Upgrading `applicaster2` to ruby 2.4 in applicaster/applicaster2#1899 gave a lot of warnings like:
`warning: constant ::Fixnum is deprecated`. New versions of `faraday` and `faraday_middleware` solve these.